### PR TITLE
refactor[api]: date validation and delete default enum

### DIFF
--- a/projetos/stock-app/api/src/schemas/enumField.ts
+++ b/projetos/stock-app/api/src/schemas/enumField.ts
@@ -3,7 +3,6 @@ enum EnumFieldType  {
     numeric = "numeric",
     date = "date",
     boolean = "boolean",
-    default = "text"
 };
 
 export { EnumFieldType };

--- a/projetos/stock-app/api/src/services/product.service.ts
+++ b/projetos/stock-app/api/src/services/product.service.ts
@@ -79,6 +79,15 @@ class ProductService {
           throw new Error('The field needs to be a booleano');
         }
       }
+
+      if (field.type == 'date') {
+        const regexValidIsDate = /^([0-2][0-9]|3[0-1])\/(0[0-9]|1[0-2])\/[0-9]{4}$/;
+        const hasValidIsDate = regexValidIsDate.test(fieldValue);
+        if (!hasValidIsDate) {
+          throw new Error('The field needs to be a date');
+        }
+      }
+
     }
 
     const created = await productRepository.createProduct(dto);
@@ -148,6 +157,15 @@ class ProductService {
           throw new Error('The field needs to be a boolean');
         }
       }
+
+      if (field.type == 'date') {
+        const regexValidIsDate = /^([0-2][0-9]|3[0-1])\/(0[0-9]|1[0-2])\/[0-9]{4}$/;
+        const hasValidIsDate = regexValidIsDate.test(fieldValue);
+        if (!hasValidIsDate) {
+          throw new Error('The field needs to be a date');
+        }
+      }
+      
     }
     const updateProduct = await productRepository.updateProduct(id, dto);
     return updateProduct


### PR DESCRIPTION
- validação do campo de data para criar e atualizar um produto.
     obs: regra de fevereiro não funcionando.

- retirada do atributo default: text, da interface enumFields.ts